### PR TITLE
STFTS521: Reset the IC when necessary and solve the stability problems

### DIFF
--- a/include/device.h
+++ b/include/device.h
@@ -20,6 +20,10 @@
 
 #pragma once
 
+NTSTATUS
+SetResetGPIO(
+	WDFIOTARGET gpio
+);
 
 EVT_WDF_DEVICE_D0_ENTRY OnD0Entry;
 

--- a/include/internal.h
+++ b/include/internal.h
@@ -106,6 +106,7 @@ typedef struct _DEVICE_EXTENSION
 	// Report
 	//
 	REPORT_CONTEXT ReportContext;
+	BOOLEAN ReportDone;
 
 	//
 	// PTP New

--- a/src/device.c
+++ b/src/device.c
@@ -226,7 +226,11 @@ Return Value:
 	return status;
 }
 
-NTSTATUS GetGPIO(WDFIOTARGET gpio, unsigned char* value)
+NTSTATUS
+GetGPIO(
+	WDFIOTARGET gpio, 
+	char* value
+)
 {
 	NTSTATUS status = STATUS_SUCCESS;
 	WDF_MEMORY_DESCRIPTOR outputDescriptor;
@@ -238,7 +242,11 @@ NTSTATUS GetGPIO(WDFIOTARGET gpio, unsigned char* value)
 	return status;
 }
 
-NTSTATUS SetGPIO(WDFIOTARGET gpio, unsigned char* value)
+NTSTATUS
+SetGPIO(
+	WDFIOTARGET gpio, 
+	unsigned char* value
+)
 {
 	NTSTATUS status = STATUS_SUCCESS;
 	WDF_MEMORY_DESCRIPTOR inputDescriptor, outputDescriptor;
@@ -251,7 +259,13 @@ NTSTATUS SetGPIO(WDFIOTARGET gpio, unsigned char* value)
 	return status;
 }
 
-NTSTATUS OpenIOTarget(PDEVICE_EXTENSION ctx, LARGE_INTEGER res, ACCESS_MASK use, WDFIOTARGET* target)
+NTSTATUS 
+OpenIOTarget(
+	PDEVICE_EXTENSION ctx, 
+	LARGE_INTEGER res, 
+	ACCESS_MASK use, 
+	WDFIOTARGET* target
+)
 {
 	NTSTATUS status = STATUS_SUCCESS;
 	WDF_OBJECT_ATTRIBUTES ObjectAttributes;
@@ -295,6 +309,49 @@ Exit:
 }
 
 NTSTATUS
+SetResetGPIO(
+	WDFIOTARGET gpio
+)
+{
+/*++
+  Routine Description:
+
+	This routine is separated from the part of setting the GPIO in OnPrepareHardware, 
+	so as to configure the GPIO of the stfts521 chip or perform a system reset when desired.
+
+--*/
+	NTSTATUS status = STATUS_SUCCESS;
+	LARGE_INTEGER delay;
+	unsigned char value;
+
+	Trace(TRACE_LEVEL_INFORMATION, TRACE_DRIVER, "Starting bring up sequence for the controller");
+
+	Trace(TRACE_LEVEL_INFORMATION, TRACE_DRIVER, "Setting reset gpio pin to low");
+
+	value = 0;
+	SetGPIO(gpio, &value);
+
+	Trace(TRACE_LEVEL_INFORMATION, TRACE_DRIVER, "Waiting...");
+
+	delay.QuadPart = -10 * TOUCH_POWER_RAIL_STABLE_TIME;
+	KeDelayExecutionThread(KernelMode, TRUE, &delay);
+
+	Trace(TRACE_LEVEL_INFORMATION, TRACE_DRIVER, "Setting reset gpio pin to high");
+
+	value = 1;
+	SetGPIO(gpio, &value);
+
+	Trace(TRACE_LEVEL_INFORMATION, TRACE_DRIVER, "Waiting...");
+
+	delay.QuadPart = -10 * TOUCH_DELAY_TO_COMMUNICATE;
+	KeDelayExecutionThread(KernelMode, TRUE, &delay);
+
+	Trace(TRACE_LEVEL_INFORMATION, TRACE_DRIVER, "Done");
+
+	return status;
+}
+
+NTSTATUS
 OnPrepareHardware(
 	IN WDFDEVICE FxDevice,
 	IN WDFCMRESLIST FxResourcesRaw,
@@ -327,8 +384,6 @@ OnPrepareHardware(
 	PDEVICE_EXTENSION devContext;
 	ULONG resourceCount;
 	ULONG i;
-	LARGE_INTEGER delay;
-	unsigned char value;
 
 	UNREFERENCED_PARAMETER(FxResourcesRaw);
 
@@ -386,37 +441,13 @@ OnPrepareHardware(
 
 	if (devContext->HasResetGpio)
 	{
-		/*
 		status = OpenIOTarget(devContext, devContext->ResetGpioId, GENERIC_READ | GENERIC_WRITE, &devContext->ResetGpio);
 		if (!NT_SUCCESS(status)) {
 			Trace(TRACE_LEVEL_ERROR, TRACE_DRIVER, "OpenIOTarget failed for Reset GPIO 0x%x", status);
 			goto exit;
 		}
 
-		Trace(TRACE_LEVEL_INFORMATION, TRACE_DRIVER, "Starting bring up sequence for the controller");
-
-		Trace(TRACE_LEVEL_INFORMATION, TRACE_DRIVER, "Setting reset gpio pin to low");
-
-		value = 0;
-		SetGPIO(devContext->ResetGpio, &value);
-
-		Trace(TRACE_LEVEL_INFORMATION, TRACE_DRIVER, "Waiting...");
-
-		delay.QuadPart = -10 * TOUCH_POWER_RAIL_STABLE_TIME;
-		KeDelayExecutionThread(KernelMode, TRUE, &delay);
-
-		Trace(TRACE_LEVEL_INFORMATION, TRACE_DRIVER, "Setting reset gpio pin to high");
-
-		value = 1;
-		SetGPIO(devContext->ResetGpio, &value);
-
-		Trace(TRACE_LEVEL_INFORMATION, TRACE_DRIVER, "Waiting...");
-
-		delay.QuadPart = -10 * TOUCH_DELAY_TO_COMMUNICATE;
-		KeDelayExecutionThread(KernelMode, TRUE, &delay);
-
-		Trace(TRACE_LEVEL_INFORMATION, TRACE_DRIVER, "Done");
-		*/
+		SetResetGPIO(devContext->ResetGpio);
 	}
 
 	//
@@ -564,6 +595,12 @@ OnPrepareHardware(
 
 		goto exit;
 	}
+
+	//
+	// Set it to FALSE after initialization to avoid a conflict 
+	// between the "TchReadReport" method and the "SetResetGPIO" operation.
+	//
+	devContext->ReportDone = FALSE;
 
 exit:
 

--- a/src/driver.c
+++ b/src/driver.c
@@ -279,6 +279,16 @@ Return Value:
 		WDF_NO_OBJECT_ATTRIBUTES,
 		&devContext->InterruptObject);
 
+	//
+	// Disable the interrupt when the device is started for the first time, 
+	// and re-enable it until the TchPowerSettingCallback method is executed, 
+	// so as to avoid conflicts in the operations of the interrupt.
+	//
+	if (NT_SUCCESS(status))
+	{
+		WdfInterruptDisable(devContext->InterruptObject);
+	}
+
 	if (!NT_SUCCESS(status))
 	{
 		Trace(

--- a/src/hid.c
+++ b/src/hid.c
@@ -291,7 +291,7 @@ Return Value:
 	//
 	if (devContext->ServiceInterruptsAfterD0Entry == TRUE)
 	{
-		Fts521ServiceInterrupts(
+		status = Fts521ServiceInterrupts(
 			devContext->TouchContext,
 			&devContext->I2CContext,
 			&devContext->ReportContext);

--- a/src/power.c
+++ b/src/power.c
@@ -21,6 +21,7 @@
 
 #include <Cross Platform Shim\compat.h>
 #include <controller.h>
+#include <device.h>
 #include <spb.h>
 #include <fts521\fts521core.h>
 #include <fts521\fts521internal.h>
@@ -181,6 +182,8 @@ TchPowerSettingCallback(
 
 			SetScanMode(SpbContext, SCAN_MODE_LOW_POWER, 0x00);
 
+			WdfInterruptDisable(devContext->InterruptObject);
+
 			break;
 		case 1:
 			Trace(
@@ -188,7 +191,26 @@ TchPowerSettingCallback(
 				TRACE_POWER,
 				"The Display is On");
 
-			SetScanMode(SpbContext, SCAN_MODE_ACTIVE, 0x01);
+			if (devContext->ReportDone)
+			{
+				// Perform a system reset of the IC.
+				SetResetGPIO(devContext->ResetGpio);
+
+				SetScanMode(SpbContext, SCAN_MODE_ACTIVE, 0x01);
+
+				// Clean Up event
+				BYTE EventBufferEmpty[256];
+				BYTE FTS521_READ_EVENTS[1] = { 0x86 };
+				FtsWriteReadU8UX(SpbContext, FTS521_READ_EVENTS, EventBufferEmpty, 3, 256);
+
+				WdfInterruptEnable(devContext->InterruptObject);
+			}
+			else
+			{
+				SetScanMode(SpbContext, SCAN_MODE_ACTIVE, 0x01);
+
+				WdfInterruptEnable(devContext->InterruptObject);
+			}
 
 			break;
 		case 2:

--- a/src/queue.c
+++ b/src/queue.c
@@ -122,8 +122,18 @@ Return Value:
 		//
 		// Dangling read requests for passing up touch data
 		//
-
+		
 		status = TchReadReport(device, Request, &requestPending);
+
+		//
+		// Avoid a conflict with the SetResetGPIO method during the processing
+		// of touch events when the device is started for the first time.
+		//
+		if (status)
+		{
+			devContext->ReportDone = TRUE;
+		}
+
 		break;
 
 	case IOCTL_HID_SET_FEATURE:


### PR DESCRIPTION
* When the screen is in the on state, perform some hard resets on the IC to improve stability.

* Execute the RESET EN GPIO startup sequence when initializing the controller in the driver.